### PR TITLE
error handling on gulp-less task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -9,7 +9,7 @@ var gulp = require('gulp'),
 gulp.task('less', function() {
   gulp.src('public/src/less/style.less')
     .pipe(sourcemaps.init())
-    .pipe(less({compress: true}))
+    .pipe(less({compress: true}).on('error', console.error.bind(console)))
     .pipe(autoprefixer())
     .pipe(minifyCss({keepBreaks: false}))
     .pipe(sourcemaps.write())


### PR DESCRIPTION
This one-liner will prevent the watch task from stopping on LESS errors. From now on, the errors will only be logged to console, but the watch task won't stop.
